### PR TITLE
Use JSON.parse instead of JSON.load for over-the-wire payloads

### DIFF
--- a/lib/cloud_context/rack.rb
+++ b/lib/cloud_context/rack.rb
@@ -8,7 +8,7 @@ module CloudContext
       context = env["HTTP_#{CloudContext.http_header}"]
       return unless context
 
-      CloudContext.update(JSON.load(context))
+      CloudContext.update(JSON.parse(context))
     rescue JSON::ParserError
     end
 

--- a/lib/cloud_context/sidekiq.rb
+++ b/lib/cloud_context/sidekiq.rb
@@ -39,7 +39,7 @@ module CloudContext
       def call(worker, job, *)
         CloudContext.contextualize do
           if job[JOB_KEY]
-            CloudContext.update(JSON.load(job.delete(JOB_KEY)))
+            CloudContext.update(JSON.parse(job.delete(JOB_KEY)))
           end
 
           yield


### PR DESCRIPTION
## Summary

Swap `JSON.load` → `JSON.parse` at the two over-the-wire call sites:

- `lib/cloud_context/rack.rb:11` — inbound HTTP header (attacker-controlled bytes)
- `lib/cloud_context/sidekiq.rb:42` — inbound Sidekiq job payload

`JSON.load` can deserialize arbitrary Ruby objects based on payload content; `JSON.parse` is restricted to strings/numbers/booleans/arrays/hashes, which is what CloudContext stores anyway (values are constrained to JSON-native types via the validation in `[]=`).

Closes #13

## Test plan

- [x] `bundle exec rspec` — 73 examples, 0 failures
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_0157eCqV7xTKTrN24p3oDWtw)_