### PR TITLE
Add each/keys/values to the CloudContext API

### DIFF
--- a/lib/cloud_context.rb
+++ b/lib/cloud_context.rb
@@ -30,12 +30,20 @@ module CloudContext
     context.delete(normalize_key(key))
   end
 
+  def each(&block)
+    context.each(&block)
+  end
+
   def empty?
     context.empty?
   end
 
   def fetch(key, *args, &block)
     context.fetch(normalize_key(key), *args, &block)
+  end
+
+  def keys
+    context.keys
   end
 
   def to_h
@@ -49,6 +57,10 @@ module CloudContext
         self[key] = value
       end
     end
+  end
+
+  def values
+    context.values
   end
 
   def size

--- a/spec/cloud_context_spec.rb
+++ b/spec/cloud_context_spec.rb
@@ -51,6 +51,51 @@ describe CloudContext do
     end
   end
 
+  describe '.each' do
+    it 'yields each key/value pair' do
+      CloudContext['a'] = 1
+      CloudContext['b'] = 2
+
+      pairs = []
+      CloudContext.each { |k, v| pairs << [k, v] }
+
+      expect(pairs).to contain_exactly(['a', 1], ['b', 2])
+    end
+
+    it 'returns an Enumerator without a block' do
+      CloudContext['a'] = 1
+
+      expect(CloudContext.each).to be_an(Enumerator)
+      expect(CloudContext.each.to_a).to eq([['a', 1]])
+    end
+  end
+
+  describe '.keys' do
+    it 'returns the keys' do
+      CloudContext['a'] = 1
+      CloudContext[:b] = 2
+
+      expect(CloudContext.keys).to contain_exactly('a', 'b')
+    end
+
+    it 'is empty when no context is set' do
+      expect(CloudContext.keys).to eq([])
+    end
+  end
+
+  describe '.values' do
+    it 'returns the values' do
+      CloudContext['a'] = 1
+      CloudContext['b'] = 'two'
+
+      expect(CloudContext.values).to contain_exactly(1, 'two')
+    end
+
+    it 'is empty when no context is set' do
+      expect(CloudContext.values).to eq([])
+    end
+  end
+
   describe '.http_header' do
     subject { described_class.http_header }
 


### PR DESCRIPTION
## Summary

Adds the three read-side enumerable primitives to `CloudContext`, each delegating to the underlying hash:

- `each` — yields `[key, value]`, returns an `Enumerator` without a block
- `keys`
- `values`

Deliberately does not `include Enumerable` (per issue): that would pull in `map`/`select`/etc. returning arrays-of-pairs, which is a different mental model from `Hash` and would surprise callers who reach for it expecting Hash-shaped results.

Closes #25

## Test plan

- [x] `bundle exec rspec` — 79 examples, 0 failures
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_0157eCqV7xTKTrN24p3oDWtw)_