### PR TITLE
Make update return self, matching Hash#update

### DIFF
--- a/lib/cloud_context.rb
+++ b/lib/cloud_context.rb
@@ -57,6 +57,8 @@ module CloudContext
         self[key] = value
       end
     end
+
+    self
   end
 
   def values

--- a/spec/cloud_context_spec.rb
+++ b/spec/cloud_context_spec.rb
@@ -163,6 +163,10 @@ describe CloudContext do
       expect(CloudContext['abc']).to eq 123
       expect(CloudContext['foo']).to eq 'bar'
     end
+
+    it 'returns self, like Hash#update' do
+      expect(CloudContext.update(abc: 123)).to be CloudContext
+    end
   end
 
   describe '.contextualize' do


### PR DESCRIPTION
## Summary

`CloudContext.update` was returning the result of `hashes.each` (the array of input hashes). `Hash#update` returns `self`, and the module is otherwise Hash-shaped, so do the same — supports chaining and removes a small papercut.

Closes #23

## Test plan

- [x] `bundle exec rspec` — 80 examples, 0 failures
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_0157eCqV7xTKTrN24p3oDWtw)_