### PR TITLE
Add validate_values config flag to skip the JSON round-trip check

### DIFF
--- a/lib/cloud_context.rb
+++ b/lib/cloud_context.rb
@@ -17,8 +17,10 @@ module CloudContext
     if value.nil?
       delete(key)
       nil
-    else
+    elsif @validate_values
       context[normalize_key(key)] = normalize_value(value)
+    else
+      context[normalize_key(key)] = value
     end
   end
 
@@ -75,8 +77,10 @@ module CloudContext
 
   # config
   attr_reader :http_header
+  attr_accessor :validate_values
 
   @http_header = 'X_CLOUD_CONTEXT'
+  @validate_values = true
   def http_header=(header)
     @http_header = header.upcase.tr('-', '_')
   end

--- a/spec/cloud_context_spec.rb
+++ b/spec/cloud_context_spec.rb
@@ -96,6 +96,46 @@ describe CloudContext do
     end
   end
 
+  describe '.validate_values' do
+    around do |example|
+      original = CloudContext.validate_values
+      example.run
+      CloudContext.validate_values = original
+    end
+
+    it 'defaults to true' do
+      expect(CloudContext.validate_values).to be true
+    end
+
+    context 'when true' do
+      before { CloudContext.validate_values = true }
+
+      it 'rejects non-JSON-roundtrippable values' do
+        expect {
+          CloudContext['abc'] = :symbol
+        }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when false' do
+      before { CloudContext.validate_values = false }
+
+      it 'skips validation' do
+        expect {
+          CloudContext['abc'] = :symbol
+        }.not_to raise_error
+
+        expect(CloudContext['abc']).to eq :symbol
+      end
+
+      it 'still routes nil through delete' do
+        CloudContext['abc'] = 123
+        CloudContext['abc'] = nil
+        expect(CloudContext).to be_empty
+      end
+    end
+  end
+
   describe '.http_header' do
     subject { described_class.http_header }
 


### PR DESCRIPTION
## Summary

Adds a global `CloudContext.validate_values` config flag (default `true`, so behavior is unchanged) that lets callers skip the JSON round-trip check in `[]=` / `update`.

```ruby
# Keep strict validation in dev/test, skip in production
CloudContext.validate_values = Rails.env.local?
```

The `nil`-as-delete behavior in `[]=` still routes through `delete` regardless of the flag.

### Why not a per-call `validate:` kwarg?

The issue floats `update(hash, validate: false)`. The trouble is `update(*hashes)` currently accepts the idiomatic `CloudContext.update(request_id: id)` — adding `validate:` as a kwarg breaks that call form in Ruby 3 (the trailing hash becomes kwargs and Ruby raises on unknown keys). If we want per-call control later, a dedicated method (`store!` / `merge!`) is a cleaner path than reshaping `update`'s signature. The global flag covers the dominant use case (production-wide opt-out).

### Benchmark

200k assignments per row, Ruby 3.3.6:

| payload | `validate=true` | `validate=false` | delta |
| --- | --- | --- | --- |
| `{ "request_id" => "abc-123" }` | 0.200s | 0.088s | **2.3× faster** |
| nested hash (user + trace) | 0.925s | 0.150s | **6.2× faster** |

Closes #22

## Test plan

- [x] `bundle exec rspec` — 84 examples, 0 failures
- [x] Local benchmark confirms the delta
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_0157eCqV7xTKTrN24p3oDWtw)_